### PR TITLE
Dynamically filter ddl datasources based on selections

### DIFF
--- a/DECIS/AssetView.aspx
+++ b/DECIS/AssetView.aspx
@@ -19,14 +19,15 @@
                             <asp:Label ID="lblAssetType" runat="server" Text="Asset Type:">
                             </asp:Label>
                             <asp:Label ID="lblAssetTypeText" CssClass="form-control bg-muted" runat="server"></asp:Label>
-                            <asp:Label ID="lblAssetStatus" runat="server" Text="Asset Status:">
-                            </asp:Label>
-                            <asp:DropDownList ID="ddlAssetStatus" CssClass="form-control" runat="server"></asp:DropDownList>
+
                             <asp:UpdatePanel ID="upMakeModel" runat="server" UpdateMode="Conditional">
                                 <Triggers>
-                                    <asp:AsyncPostBackTrigger ControlID="ddlAssetMake" EventName="SelectedIndexChanged" />
+                                    <asp:AsyncPostBackTrigger ControlID="ddlAssetMake" EventName="SelectedIndexChanged" />                                    <asp:AsyncPostBackTrigger ControlID="ddlAssetMake" EventName="SelectedIndexChanged" />
+                                    <asp:AsyncPostBackTrigger ControlID="ddlAssetStatus" EventName="SelectedIndexChanged" />
                                 </Triggers>
                                 <ContentTemplate>
+                                    <asp:Label ID="lblAssetStatus" runat="server" Text="Asset Status:"></asp:Label>
+                                    <asp:DropDownList ID="ddlAssetStatus" CssClass="form-control" runat="server" OnSelectedIndexChanged="ddlAssetStatus_SelectedIndexChanged" AutoPostBack="True"></asp:DropDownList>
                                     <asp:Label ID="lblAssetMake" runat="server" Text="Asset Make:">
                                     </asp:Label>
                                     <asp:DropDownList ID="ddlAssetMake" CssClass="form-control" runat="server" OnSelectedIndexChanged="ddlAssetMake_SelectedIndexChanged" AutoPostBack="True"></asp:DropDownList>
@@ -39,10 +40,17 @@
                         <div class="col-md">
                             <asp:Label ID="lblAssetDescription" runat="server" Text="Asset Description:">
                             </asp:Label><asp:TextBox ID="tbAssetDescription" CssClass="form-control" runat="server"></asp:TextBox>
-                            <asp:Label ID="lblLocation" runat="server" Text="Location:"></asp:Label>
-                            <asp:DropDownList ID="ddlLocation" CssClass="form-control" runat="server"></asp:DropDownList>
-                            <asp:Label ID="lblLocationDescription" runat="server" Text="Location Description:"></asp:Label>
-                            <asp:Label ID="lblLocationDescriptionText" CssClass="bg-muted form-control" runat="server"></asp:Label>
+                            <asp:UpdatePanel ID="upLocation" UpdateMode="Conditional" runat="server">
+                                <Triggers>
+                                    <asp:AsyncPostBackTrigger ControlID="ddlLocation" EventName="SelectedIndexChanged" />
+                                </Triggers>
+                                <ContentTemplate>
+                                    <asp:Label ID="lblLocation" runat="server" Text="Location:"></asp:Label>
+                                    <asp:DropDownList ID="ddlLocation" CssClass="form-control" runat="server" AutoPostBack="True" OnSelectedIndexChanged="ddlLocation_SelectedIndexChanged"></asp:DropDownList>
+                                    <asp:Label ID="lblLocationDescription" runat="server" Text="Location Description:"></asp:Label>
+                                    <asp:Label ID="lblLocationDescriptionText" CssClass="bg-muted form-control" runat="server"></asp:Label>
+                                </ContentTemplate>
+                            </asp:UpdatePanel>
                         </div>
                     </asp:Panel>
                     <%-- Content End --%>

--- a/DECIS/AssetView.aspx.cs
+++ b/DECIS/AssetView.aspx.cs
@@ -52,6 +52,7 @@ namespace DECIS
         {
             List<DropDownList> ddls = new List<DropDownList>() { ddlAssetMake, ddlAssetModel, ddlAssetStatus, ddlLocation };
             DataSet dts = DDLDataBind.ddlBind(ddls, curAsset.MakeID);
+
             ViewState["Models"] = dts.Tables["Model"];
             ViewState["Locations"] = dts.Tables["Location"];
         }
@@ -125,5 +126,22 @@ namespace DECIS
 
         }
 
+        protected void ddlLocation_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            DropDownList ddl = (DropDownList)sender;
+            lblLocationDescriptionText.Text = new GetLocationInfoByID().ExecuteCommand(int.Parse(ddl.SelectedValue)).Rows[0]["LocationDescription"].ToString();
+            upLocation.Update();
+        }
+
+        protected void ddlAssetStatus_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            DropDownList ddl = (DropDownList)sender;
+            DataTable locs = new GetLocationByStatus().ExecuteCommand(ddl.SelectedItem.Text);
+            if (locs == null || locs.Rows.Count == 0)
+                ddlLocation.Items.Insert(0, new ListItem("No valid locations", "-1"));
+            ddlLocation.DataSource = locs;
+            ddlLocation.DataBind();
+            upLocation.Update();
+        }
     }
 }

--- a/DECIS/AssetView.aspx.designer.cs
+++ b/DECIS/AssetView.aspx.designer.cs
@@ -58,6 +58,15 @@ namespace DECIS {
         protected global::System.Web.UI.WebControls.Label lblAssetTypeText;
         
         /// <summary>
+        /// upMakeModel control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.UpdatePanel upMakeModel;
+        
+        /// <summary>
         /// lblAssetStatus control.
         /// </summary>
         /// <remarks>
@@ -74,15 +83,6 @@ namespace DECIS {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.DropDownList ddlAssetStatus;
-        
-        /// <summary>
-        /// upMakeModel control.
-        /// </summary>
-        /// <remarks>
-        /// Auto-generated field.
-        /// To modify move field declaration from designer file to code-behind file.
-        /// </remarks>
-        protected global::System.Web.UI.UpdatePanel upMakeModel;
         
         /// <summary>
         /// lblAssetMake control.
@@ -137,6 +137,15 @@ namespace DECIS {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.TextBox tbAssetDescription;
+        
+        /// <summary>
+        /// upLocation control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.UpdatePanel upLocation;
         
         /// <summary>
         /// lblLocation control.

--- a/DECIS/ControlLogic/DDL/DDLDataBind.cs
+++ b/DECIS/ControlLogic/DDL/DDLDataBind.cs
@@ -33,7 +33,7 @@ namespace DECIS.CotrolLogic
             if (makeID > -1)
             {
                 DropDownList model = ddls.First(ddl => ddl.ID == "ddlAssetModel") as DropDownList;
-                AssetModel(model, makeID);
+                dts.Tables.Add(AssetModel(model, makeID));
                 ddls.Remove(model);
             }
             foreach(DropDownList ddl in ddls)
@@ -50,6 +50,7 @@ namespace DECIS.CotrolLogic
         private static DataTable AssetModel(DropDownList ddl)
         {
             DataTable modelDT = new GetAllModel().ExecuteCommand();
+            modelDT.TableName = "Model";
             ddl.DataSource = modelDT;
             ddl.DataTextField = "Model";
             ddl.DataValueField = "ModelID";
@@ -61,6 +62,7 @@ namespace DECIS.CotrolLogic
         private static DataTable AssetModel(DropDownList ddl, int makeID)
         {
             DataTable modelDT = new GetAllModel().ExecuteCommand();
+            modelDT.TableName = "Model";
             ddl.DataSource = modelDT.AsEnumerable().Where(r => r.Field<int>("Make") == makeID).CopyToDataTable();
             ddl.DataTextField = "Model";
             ddl.DataValueField = "ModelID";
@@ -72,7 +74,7 @@ namespace DECIS.CotrolLogic
         private static DataTable AssetMake(DropDownList ddl)
         {
             DataTable makeDT = new GetAllMake().ExecuteCommand();
-
+            makeDT.TableName = "Make";
             ddl.DataSource = makeDT;
             ddl.DataTextField = "Make";
             ddl.DataValueField = "MakeID";
@@ -84,7 +86,7 @@ namespace DECIS.CotrolLogic
         private static DataTable AssetStatus(DropDownList ddl)
         {
             DataTable statusDT = new GetAllStatus().ExecuteCommand();
-
+            statusDT.TableName = "Status";
             ddl.DataSource = statusDT;
             ddl.DataTextField = "Status";
             ddl.DataValueField = "StatusID";
@@ -96,7 +98,7 @@ namespace DECIS.CotrolLogic
         private static DataTable AssetLocation(DropDownList ddl)
         {
             DataTable locationDT = new GetAllLocation().ExecuteCommand();
-
+            locationDT.TableName = "Location";
             ddl.DataSource = locationDT;
             ddl.DataTextField = "Location";
             ddl.DataValueField = "LocationID";
@@ -108,10 +110,10 @@ namespace DECIS.CotrolLogic
         private static DataTable AssetLocationDescription(DropDownList ddl)
         {
             DataTable locationDT = new GetAllLocation().ExecuteCommand();
-
+            locationDT.TableName = "Location";
             ddl.DataSource = locationDT;
             ddl.DataTextField = "LocationDescription";
-            ddl.DataValueField = "LocationDescriptionID";
+            ddl.DataValueField = "LocationID";
             ddl.DataBind();
 
             return locationDT;
@@ -120,7 +122,7 @@ namespace DECIS.CotrolLogic
         private static DataTable AssetType(DropDownList ddl)
         {
             DataTable typeDT = new GetAllAssetTypes().ExecuteCommand();
-
+            typeDT.TableName = "AssetType";
             ddl.DataSource = typeDT;
             ddl.DataTextField = "AssetType";
             ddl.DataValueField = "AssetTypeID";


### PR DESCRIPTION
Update DDLs to rebind dataset filtered for selections. E.g. Setting status to good will make Location update to only valid locations that belong to the good status.

Updating location DDL will update the location description field

Fix Model DT to be added to dataset after original binding. 